### PR TITLE
Using Zulu builds of OpenJDK in GH actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,15 +6,17 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-
+    strategy:
+      matrix:
+        java-version: [ 16 ]
     steps:
     - name: Clone repo
       uses: actions/checkout@v2
-    - name: Set up JDK 16
+    - name: Set up JDK ${{ matrix.java-version }}
       uses: actions/setup-java@v2
       with:
-        distribution: 'adopt'
-        java-version: '16'
+        distribution: 'zulu'
+        java-version: ${{ matrix.java-version }}
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
     - name: Build with Gradle


### PR DESCRIPTION
The AdoptOpenJDK has been discontinued Since July 2021. When using Zulu you get all the latest updated (TCK tested) builds for all versions of OpenJDK. Gradle currently does not support early access releases of OpenJDK builds. I've added a matrix (array) to add the next LTS release (JDK 17) when it becomes GA. 
Note: If using Maven it's possible to add 17-ea. 💯 